### PR TITLE
Add Option: show Window Icons Rather Than Desktop Number

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -10,6 +10,10 @@
 			<label>Show Desktop names rather than numbers</label>
 			<default>false</default>
 		</entry>
+		<entry name="showWindowIcons" type="Bool">
+			<label>Show window icons rather than numbers</label>
+			<default>false</default>
+		</entry>
 		<entry name="stayVisible" type="Bool">
 			<label>Whether to stay visible when there is only one virtual desktop</label>
 			<default>true</default>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -14,6 +14,10 @@
 			<label>Show window icons rather than numbers</label>
 			<default>false</default>
 		</entry>
+		<entry name="showOnlyCurrentScreen" type="Bool">
+			<label>Only show windows from current Screen in pager</label>
+			<default>false</default>
+		</entry>
 		<entry name="stayVisible" type="Bool">
 			<label>Whether to stay visible when there is only one virtual desktop</label>
 			<default>true</default>

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -35,6 +35,7 @@ KCM.SimpleKCM {
 	property alias cfg_stayVisible: stayVisible.checked
 	property alias cfg_showDesktopNames: showDesktopNames.checked
 	property alias cfg_showWindowIcons: showWindowIcons.checked
+	property alias cfg_showOnlyCurrentScreen: showOnlyCurrentScreen.checked
 
 	Kirigami.FormLayout {
 		id: layoutGeneral
@@ -55,6 +56,11 @@ KCM.SimpleKCM {
 			id: wrapPage
 			enabled: cfg_enableScrolling
 			text: i18n("Navigation wraps around")
+		}
+
+		QtControls.CheckBox {
+			id: showOnlyCurrentScreen
+			text: i18n("Only show windows from current Screen in pager")
 		}
 
 		Item {

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -42,16 +42,6 @@ KCM.SimpleKCM {
 		//anchors.fill: parent
 
 		QtControls.CheckBox {
-			id: showDesktopNames
-			text: i18n("Show Desktop names rather than numbers")
-		}
-
-		QtControls.CheckBox {
-			id: showWindowIcons
-			text: i18n("Show window icons rather than numbers")
-		}
-
-		QtControls.CheckBox {
 			id: stayVisible
 			text: i18n("Stay visible when there is only one virtual desktop")
 		}
@@ -65,6 +55,31 @@ KCM.SimpleKCM {
 			id: wrapPage
 			enabled: cfg_enableScrolling
 			text: i18n("Navigation wraps around")
+		}
+
+		Item {
+			Kirigami.FormData.isSection: true
+		}
+
+		QtControls.ButtonGroup {
+			buttons: [showDesktopNumbers, showDesktopNames, showWindowIcons]
+		}
+
+		QtControls.RadioButton {
+			id: showDesktopNumbers
+			Kirigami.FormData.label: i18n("What to show in box:")
+			text: i18n("Show desktop numbers")
+			checked: !showDesktopNames.checked && !showWindowIcons.checked
+		}
+
+		QtControls.RadioButton {
+			id: showDesktopNames
+			text: i18n("Show desktop names")
+		}
+
+		QtControls.RadioButton {
+			id: showWindowIcons
+			text: i18n("Show window icons")
 		}
 
 		Item {

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -34,6 +34,7 @@ KCM.SimpleKCM {
 	property alias cfg_actionOnCompactLayout: actionOnCompactLayout.checked
 	property alias cfg_stayVisible: stayVisible.checked
 	property alias cfg_showDesktopNames: showDesktopNames.checked
+	property alias cfg_showWindowIcons: showWindowIcons.checked
 
 	Kirigami.FormLayout {
 		id: layoutGeneral
@@ -43,6 +44,11 @@ KCM.SimpleKCM {
 		QtControls.CheckBox {
 			id: showDesktopNames
 			text: i18n("Show Desktop names rather than numbers")
+		}
+
+		QtControls.CheckBox {
+			id: showWindowIcons
+			text: i18n("Show window icons rather than numbers")
 		}
 
 		QtControls.CheckBox {

--- a/package/contents/ui/lib/NumberBox.qml
+++ b/package/contents/ui/lib/NumberBox.qml
@@ -17,6 +17,7 @@
  */
 
 import QtQuick
+import QtQuick.Layouts
 import org.kde.plasma.plasmoid
 import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.components as PlasmaComponents
@@ -31,6 +32,7 @@ Rectangle {
 	property color fontColor: plasmoid.configuration.fontColorChecked ? 
 			plasmoid.configuration.fontColor : Kirigami.Theme.textColor
 	property bool showWindowIndicator: true
+	property list<var> iconSources: []
 
 	border.width: plasmoid.configuration.displayBorder ? plasmoid.configuration.borderThickness : 0
 	radius: height > width ? height * (plasmoid.configuration.borderRadius / 100) : width * (plasmoid.configuration.borderRadius / 100)
@@ -61,6 +63,7 @@ Rectangle {
 
 	Text {
 		id: numberText
+		visible: !plasmoid.configuration.showWindowIcons
 		anchors.centerIn: parent
 		text: pagerModel.currentPage + 1
 		color: fontColor
@@ -71,4 +74,39 @@ Rectangle {
 			pixelSize: fontSizeChecked ? plasmoid.configuration.fontSize : Math.min(parent.height*0.7, parent.width*0.7)
 		}
 	}
+
+	Grid {
+		id: iconGrid
+		anchors.centerIn: parent
+		visible: plasmoid.configuration.showWindowIcons
+
+		readonly property int maxIconCount: 3
+		readonly property bool showIconsInColumn: numberBox.height > numberBox.width
+		readonly property bool showAllIcons: numberBox.iconSources.length <= maxIconCount
+		readonly property int iconSize: Math.min(numberBox.height * 0.7, numberBox.width * 0.7)
+
+		columns: showIconsInColumn ? 1 : maxIconCount
+		rows: showIconsInColumn ? maxIconCount : 1
+		flow: showIconsInColumn ? Grid.TopToBottom : Grid.LeftToRight
+
+		component BoxIcon: Kirigami.Icon {
+			height: iconGrid.iconSize
+			width: iconGrid.iconSize
+			roundToIconSize: false
+		}
+
+		Repeater {
+			model: numberBox.iconSources
+			BoxIcon {
+				visible: iconGrid.showAllIcons
+				source: modelData
+			}
+		}
+
+		BoxIcon {
+			visible: !iconGrid.showAllIcons
+			source: iconGrid.showIconsInColumn ? "view-more-symbolic" : "view-more-horizontal-symbolic"
+		}
+	}
+
 }

--- a/package/contents/ui/lib/NumberBox.qml
+++ b/package/contents/ui/lib/NumberBox.qml
@@ -80,13 +80,13 @@ Rectangle {
 		anchors.centerIn: parent
 		visible: plasmoid.configuration.showWindowIcons
 
-		readonly property int maxIconCount: 3
+		readonly property int maxIconCount: Math.floor(Math.max(numberBox.height, numberBox.width) / iconSize)
 		readonly property bool showIconsInColumn: numberBox.height > numberBox.width
 		readonly property bool showAllIcons: numberBox.iconSources.length <= maxIconCount
 		readonly property int iconSize: Math.min(numberBox.height * 0.7, numberBox.width * 0.7)
 
-		columns: showIconsInColumn ? 1 : maxIconCount
-		rows: showIconsInColumn ? maxIconCount : 1
+		columns: (showIconsInColumn || !showAllIcons) ? 1 : maxIconCount
+		rows: (showIconsInColumn && showAllIcons) ? maxIconCount : 1
 		flow: showIconsInColumn ? Grid.TopToBottom : Grid.LeftToRight
 
 		component BoxIcon: Kirigami.Icon {

--- a/package/contents/ui/lib/ReprLayout.qml
+++ b/package/contents/ui/lib/ReprLayout.qml
@@ -179,9 +179,5 @@ GridLayout {
 				}
 			}
 		}
-
-		Component.onCompleted: {
-			pagerModel.showOnlyCurrentScreen = true;
-		}
 	}
 }

--- a/package/contents/ui/lib/ReprLayout.qml
+++ b/package/contents/ui/lib/ReprLayout.qml
@@ -128,9 +128,22 @@ GridLayout {
 			Repeater {
 				id: proxyRepeater
 				model: TasksModel
-				Rectangle { visible: false }
+				Item {
+					visible: false
+					property var iconSource: model.decoration
+				}
 			}
+
 			showWindowIndicator: plasmoid.configuration.showWindowIndicator && proxyRepeater.count > 0
+
+			iconSources: {
+				const result = [];
+				for (let i = 0; i < proxyRepeater.count; i++) {
+					const taskProxy = proxyRepeater.itemAt(i);
+					result.push(taskProxy.iconSource);
+				}
+				return result;
+			}
 
 			//highlight the current desktop
 			color: index === pagerModel.currentPage ? bgColorHighlight :
@@ -165,6 +178,10 @@ GridLayout {
 					}
 				}
 			}
+		}
+
+		Component.onCompleted: {
+			pagerModel.showOnlyCurrentScreen = true;
 		}
 	}
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -116,7 +116,7 @@ PlasmoidItem {
 
 		showDesktop: (plasmoid.configuration.currentDesktopSelected === 1)
 
-		showOnlyCurrentScreen: false
+		showOnlyCurrentScreen: plasmoid.configuration.showOnlyCurrentScreen
 		screenGeometry: root.screenGeometry
 
 		pagerType: PagerModel.VirtualDesktops


### PR DESCRIPTION
Hi, thanks for this awesome plasmoid! I made some modification to allow users to show windows icons on a virtual desktop rather than desktop number. It's something I've used myself for a few months and it fits my own usage perfectly, and I think it'll be great to merge back.
![image](https://github.com/user-attachments/assets/e85f0634-7de7-4a35-b487-8c0afbc15c0e)
I also rearranged the config dialog a little bit to make "what to show" options less messy.